### PR TITLE
Fix inverted bearer token condition and Person mock serialization

### DIFF
--- a/src/HttpClientServiceHelper.Tests/Mock/Person.cs
+++ b/src/HttpClientServiceHelper.Tests/Mock/Person.cs
@@ -6,9 +6,9 @@ namespace HttpClientServiceHelper.Tests.Mock
 {
     public class Person
     {
-        private string FirstName { get; set; }
-        private string LastName { get; set; }
-        private string FullName => $"{FirstName} {LastName}";
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string FullName => $"{FirstName} {LastName}";
 
         public static Person GetPerson()
         {

--- a/src/HttpClientServiceHelper/Delete.cs
+++ b/src/HttpClientServiceHelper/Delete.cs
@@ -33,7 +33,7 @@ namespace HttpClientServiceHelper
         {
             using (HttpClient httpClient = new HttpClient())
             {
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
                 return httpResponse;
             }
@@ -101,7 +101,7 @@ namespace HttpClientServiceHelper
         {
             using (HttpClient httpClient = new HttpClient())
             {
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
                 return await httpResponse.Content.ReadAsStringAsync();
             }
@@ -195,7 +195,7 @@ namespace HttpClientServiceHelper
         //{
         //    using (HttpClient httpClient = new HttpClient())
         //    {
-        //        httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+        //        httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
         //        var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
         //        if (httpResponse.IsSuccessStatusCode)
         //        {

--- a/src/HttpClientServiceHelper/Get.cs
+++ b/src/HttpClientServiceHelper/Get.cs
@@ -62,7 +62,7 @@ namespace HttpClientServiceHelper
         //{
         //    using (HttpClient httpClient = new HttpClient())
         //    {
-        //        httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+        //        httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
         //        var httpResponse = await httpClient.GetAsync(new Uri(Route));
         //        if (httpResponse.IsSuccessStatusCode)
         //        {
@@ -208,7 +208,7 @@ namespace HttpClientServiceHelper
         {
             using (HttpClient httpClient = new HttpClient())
             {
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 var httpResponse = await httpClient.GetAsync(new Uri(Route));
                 return httpResponse;
             }
@@ -276,7 +276,7 @@ namespace HttpClientServiceHelper
         {
             using (HttpClient httpClient = new HttpClient())
             {
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 var httpResponse = await httpClient.GetAsync(new Uri(Route));
                 return await httpResponse.Content.ReadAsStringAsync();
             }

--- a/src/HttpClientServiceHelper/Patch.cs
+++ b/src/HttpClientServiceHelper/Patch.cs
@@ -40,7 +40,7 @@ namespace HttpClientServiceHelper
             using (HttpClient httpClient = new HttpClient())
             {
                 var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 string jsonTransport = JsonConvert.SerializeObject(Model);
                 var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
                 var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
@@ -124,7 +124,7 @@ namespace HttpClientServiceHelper
             using (HttpClient httpClient = new HttpClient())
             {
                 var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 string jsonTransport = JsonConvert.SerializeObject(Model);
                 var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
                 var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
@@ -234,7 +234,7 @@ namespace HttpClientServiceHelper
         //    using (HttpClient httpClient = new HttpClient())
         //    {
         //        var uri = new Uri(Route);
-        //        httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+        //        httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
         //        string jsonTransport = JsonConvert.SerializeObject(Model);
         //        var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
         //        var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);

--- a/src/HttpClientServiceHelper/Post.cs
+++ b/src/HttpClientServiceHelper/Post.cs
@@ -40,7 +40,7 @@ namespace HttpClientServiceHelper
             using (HttpClient httpClient = new HttpClient())
             {
                 var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 string jsonTransport = JsonConvert.SerializeObject(Model);
                 var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
                 var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
@@ -124,7 +124,7 @@ namespace HttpClientServiceHelper
             using (HttpClient httpClient = new HttpClient())
             {
                 var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 string jsonTransport = JsonConvert.SerializeObject(Model);
                 var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
                 var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
@@ -234,7 +234,7 @@ namespace HttpClientServiceHelper
         //    using (HttpClient httpClient = new HttpClient())
         //    {
         //        var uri = new Uri(Route);
-        //        httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+        //        httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
         //        string jsonTransport = JsonConvert.SerializeObject(Model);
         //        var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
         //        var httpResponse = await httpClient.PostAsync(uri, jsonPayload);

--- a/src/HttpClientServiceHelper/Put.cs
+++ b/src/HttpClientServiceHelper/Put.cs
@@ -40,7 +40,7 @@ namespace HttpClientServiceHelper
             using (HttpClient httpClient = new HttpClient())
             {
                 var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 string jsonTransport = JsonConvert.SerializeObject(Model);
                 var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
                 var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
@@ -124,7 +124,7 @@ namespace HttpClientServiceHelper
             using (HttpClient httpClient = new HttpClient())
             {
                 var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
                 string jsonTransport = JsonConvert.SerializeObject(Model);
                 var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
                 var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
@@ -234,7 +234,7 @@ namespace HttpClientServiceHelper
         //    using (HttpClient httpClient = new HttpClient())
         //    {
         //        var uri = new Uri(Route);
-        //        httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
+        //        httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
         //        string jsonTransport = JsonConvert.SerializeObject(Model);
         //        var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
         //        var httpResponse = await httpClient.PutAsync(uri, jsonPayload);


### PR DESCRIPTION
## Summary
- All token-based overloads across `Get`, `Post`, `Delete`, `Put`, and `Patch` had an inverted `IsNullOrEmpty` check — the `Authorization` header was set when the token was empty and cleared when it had a value. Added `!` to `string.IsNullOrEmpty(Token)` in all 10 locations. Fixes #34
- `Person.FirstName`, `LastName`, and `FullName` were `private`, causing `JsonConvert.SerializeObject` to produce `{}` in all POST/PUT/PATCH test payloads. Made all three properties `public`. Fixes #35

## Test plan
- [ ] Valid bearer token now sets `Authorization: Bearer <token>` correctly
- [ ] Passing `null` or `""` results in no `Authorization` header
- [ ] POST/PUT/PATCH tests now send a non-empty JSON body
- [ ] All 21 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)