### PR TITLE
Bump version to 1.0.13 and publish to NuGet

### DIFF
--- a/src/HttpClientServiceHelper/HttpClientServiceHelper.csproj
+++ b/src/HttpClientServiceHelper/HttpClientServiceHelper.csproj
@@ -13,7 +13,7 @@ It returns an HttpResponseMessage/String Response depending on the method called
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RepositoryUrl>https://github.com/DaraOladapo/HttpClientServiceHelper</RepositoryUrl>
     <ReleaseVersion>0.11</ReleaseVersion>
-    <Version>1.0.12</Version>
+    <Version>1.0.13</Version>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <AssemblyName>Http Client Service Helper</AssemblyName>
     <PackageId>HttpClientServiceHelper</PackageId>


### PR DESCRIPTION
## Summary

- Bumps `<Version>` in `HttpClientServiceHelper.csproj` from `1.0.12` → `1.0.13`
- Package builds and packs cleanly (`HttpClientServiceHelper.1.0.13.nupkg`)

Closes #44

## Test plan

- [x] `dotnet build` passes with 0 warnings/errors
- [x] `dotnet pack` produces `HttpClientServiceHelper.1.0.13.nupkg` successfully
- [ ] Merge and publish to NuGet.org

🤖 Generated with [Claude Code](https://claude.ai/claude-code)