### PR TITLE
fix: replace per-call HttpClient with shared static instance to prevent socket exhaustion

### DIFF
--- a/src/HttpClientServiceHelper/Delete.cs
+++ b/src/HttpClientServiceHelper/Delete.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -17,11 +17,7 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            return await _httpClient.DeleteAsync(new Uri(Route));
         }
         /// <summary>
         /// Triggers a DELETE request to the specified route with a Bearer token and retrieves the result as a string which you can serialize.
@@ -31,12 +27,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a DELETE request with headers to the specified route and retrieves the result as a string which you can serialize.
@@ -46,15 +40,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a DELETE request with headers and authorization to the specified route and retrieves the result as a string which you can serialize.
@@ -65,17 +54,13 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                     new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -85,11 +70,8 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var httpResponse = await _httpClient.DeleteAsync(new Uri(Route));
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a DELETE request to the specified route with a Bearer token and retrieves the result as a string which you can serialize.
@@ -99,12 +81,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a DELETE request with headers to the specified route and retrieves the result as a string which you can serialize.
@@ -114,15 +95,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a DELETE request with headers and authorization to the specified route and retrieves the result as a string which you can serialize.
@@ -133,17 +110,14 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
 
         /// <summary>

--- a/src/HttpClientServiceHelper/Get.cs
+++ b/src/HttpClientServiceHelper/Get.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -13,6 +13,9 @@ namespace HttpClientServiceHelper
     /// </summary>
     public partial class HttpClientHelper
     {
+        // Shared instance — reusing a single HttpClient avoids socket exhaustion from per-call disposal.
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         #region TODO
         /// <summary>
         /// Triggers a GET request to the specified route and retrieves the result as a generic object response.
@@ -192,11 +195,7 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            return await _httpClient.GetAsync(new Uri(Route));
         }
         /// <summary>
         /// Triggers a GET request to the specified route with a Bearer Token and retrieves the result as an HTTP Response Message.
@@ -206,12 +205,10 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a GET request with headers to the specified route and retrieves the result as an HTTP Response Message.
@@ -221,15 +218,10 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a GET request with headers and authorization to the specified route and retrieves the result as an HTTP Response Message.
@@ -240,17 +232,13 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -260,11 +248,8 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var httpResponse = await _httpClient.GetAsync(new Uri(Route));
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a GET request to the specified route with a Bearer Token and retrieves the result as an HTTP Response Message.
@@ -274,12 +259,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a GET request with headers to the specified route and retrieves the result as an HTTP Response Message.
@@ -289,15 +273,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a GET request with headers and authorization to the specified route and retrieves the result as an HTTP Response Message.
@@ -308,17 +288,14 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
     }
 }

--- a/src/HttpClientServiceHelper/Patch.cs
+++ b/src/HttpClientServiceHelper/Patch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -19,14 +19,9 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Patch request to the specified route and retrieves the result as an HTTP Response Message
@@ -37,15 +32,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -56,18 +47,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -79,20 +63,14 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -103,14 +81,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Patch request to the specified route and retrieves the result as an HTTP Response Message.
@@ -121,15 +95,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -140,18 +111,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -163,20 +128,15 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         #region TODO
         /// <summary>

--- a/src/HttpClientServiceHelper/Post.cs
+++ b/src/HttpClientServiceHelper/Post.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -19,14 +19,9 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Post request to the specified route and retrieves the result as an HTTP Response Message
@@ -37,15 +32,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -56,18 +47,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -79,20 +63,14 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -103,14 +81,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Post request to the specified route and retrieves the result as an HTTP Response Message.
@@ -121,15 +95,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -140,18 +111,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -163,20 +128,15 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         #region TODO
         /// <summary>

--- a/src/HttpClientServiceHelper/Put.cs
+++ b/src/HttpClientServiceHelper/Put.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -19,14 +19,9 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a PUT request to the specified route and retrieves the result as an HTTP Response Message
@@ -37,15 +32,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -56,18 +47,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -79,20 +63,14 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -103,14 +81,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a PUT request to the specified route and retrieves the result as an HTTP Response Message.
@@ -121,15 +95,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -140,18 +111,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -163,20 +128,15 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            using var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.TryAddWithoutValidation(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         #region TODO
         /// <summary>


### PR DESCRIPTION
## Summary

- Fixes the `new HttpClient()` per-call anti-pattern across all five verb files (`Get.cs`, `Post.cs`, `Put.cs`, `Patch.cs`, `Delete.cs`)
- Introduces a single `private static readonly HttpClient _httpClient` on the partial class (declared in `Get.cs`, shared across all partials)
- Methods with per-request headers or auth now use `HttpRequestMessage` + `SendAsync` so headers are scoped to the individual request and never mutate `DefaultRequestHeaders` on the shared instance — thread-safe under concurrent calls
- Simple no-header overloads use the `HttpClient` convenience methods (`GetAsync`, `DeleteAsync`) directly
- Zero breaking changes — all public signatures are identical

Closes #36

## Why this matters

Disposing `HttpClient` inside a `using` block does **not** immediately release the underlying TCP socket — it enters `TIME_WAIT`. Under any meaningful request load this exhausts the local socket pool and causes `SocketException`. This is a well-documented .NET anti-pattern ([Microsoft docs](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines)).

## Test plan

- [ ] All existing WireMock tests pass (`dotnet test`)
- [ ] `GetAsync_NoAuth_DoesNotSendAuthHeader` confirms no header leakage between calls on the shared instance
- [ ] `GetAsync_WithToken_SendsBearerHeader` confirms per-request auth is still correctly applied

https://claude.ai/code/session_01VwmzESpT2AXosoWQKJtuuQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwmzESpT2AXosoWQKJtuuQ)_