### PR TITLE
fix: replace per-call new HttpClient() with shared static instance

### DIFF
--- a/src/HttpClientServiceHelper/Delete.cs
+++ b/src/HttpClientServiceHelper/Delete.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -17,11 +17,8 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a DELETE request to the specified route with a Bearer token and retrieves the result as a string which you can serialize.
@@ -31,12 +28,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a DELETE request with headers to the specified route and retrieves the result as a string which you can serialize.
@@ -46,15 +41,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a DELETE request with headers and authorization to the specified route and retrieves the result as a string which you can serialize.
@@ -65,17 +55,13 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> DeleteAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                     new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -85,11 +71,9 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a DELETE request to the specified route with a Bearer token and retrieves the result as a string which you can serialize.
@@ -99,12 +83,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a DELETE request with headers to the specified route and retrieves the result as a string which you can serialize.
@@ -114,15 +97,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a DELETE request with headers and authorization to the specified route and retrieves the result as a string which you can serialize.
@@ -133,17 +112,14 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> DeleteAndGetResponseAsStringAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.DeleteAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Delete, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
 
         /// <summary>

--- a/src/HttpClientServiceHelper/Get.cs
+++ b/src/HttpClientServiceHelper/Get.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -13,6 +13,8 @@ namespace HttpClientServiceHelper
     /// </summary>
     public partial class HttpClientHelper
     {
+        private static readonly HttpClient _httpClient = new HttpClient();
+
         #region TODO
         /// <summary>
         /// Triggers a GET request to the specified route and retrieves the result as a generic object response.
@@ -192,11 +194,8 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a GET request to the specified route with a Bearer Token and retrieves the result as an HTTP Response Message.
@@ -206,12 +205,10 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a GET request with headers to the specified route and retrieves the result as an HTTP Response Message.
@@ -221,15 +218,10 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a GET request with headers and authorization to the specified route and retrieves the result as an HTTP Response Message.
@@ -240,17 +232,13 @@ namespace HttpClientServiceHelper
         /// <returns>An HTTP Reponse Message</returns>
         public static async Task<HttpResponseMessage> GetAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -260,11 +248,9 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a GET request to the specified route with a Bearer Token and retrieves the result as an HTTP Response Message.
@@ -274,12 +260,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a GET request with headers to the specified route and retrieves the result as an HTTP Response Message.
@@ -289,15 +274,11 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a GET request with headers and authorization to the specified route and retrieves the result as an HTTP Response Message.
@@ -308,17 +289,14 @@ namespace HttpClientServiceHelper
         /// <returns>a string format of the HTTP Response message</returns>
         public static async Task<string> GetAsStringAsync(string Route, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                var httpResponse = await httpClient.GetAsync(new Uri(Route));
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
     }
 }

--- a/src/HttpClientServiceHelper/Patch.cs
+++ b/src/HttpClientServiceHelper/Patch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -19,14 +19,9 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Patch request to the specified route and retrieves the result as an HTTP Response Message
@@ -37,15 +32,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -56,18 +47,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -79,20 +63,14 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PatchAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -103,14 +81,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Patch request to the specified route and retrieves the result as an HTTP Response Message.
@@ -121,15 +95,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -140,18 +111,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Patch request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -163,20 +128,15 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PatchAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PatchAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Patch, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         #region TODO
         /// <summary>

--- a/src/HttpClientServiceHelper/Post.cs
+++ b/src/HttpClientServiceHelper/Post.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -19,14 +19,9 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Post request to the specified route and retrieves the result as an HTTP Response Message
@@ -37,15 +32,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -56,18 +47,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -79,20 +63,14 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PostAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -103,14 +81,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Post request to the specified route and retrieves the result as an HTTP Response Message.
@@ -121,15 +95,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -140,18 +111,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a Post request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -163,20 +128,15 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PostAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PostAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         #region TODO
         /// <summary>

--- a/src/HttpClientServiceHelper/Put.cs
+++ b/src/HttpClientServiceHelper/Put.cs
@@ -1,4 +1,4 @@
-﻿using HttpClientServiceHelper.Models;
+using HttpClientServiceHelper.Models;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -19,14 +19,9 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a PUT request to the specified route and retrieves the result as an HTTP Response Message
@@ -37,15 +32,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -56,18 +47,11 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -79,20 +63,14 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message</returns>
         public static async Task<HttpResponseMessage> PutAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return httpResponse;
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -103,14 +81,10 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a PUT request to the specified route and retrieves the result as an HTTP Response Message.
@@ -121,15 +95,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model, string Token = null)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                httpClient.DefaultRequestHeaders.Authorization = !string.IsNullOrEmpty(Token) ? new AuthenticationHeaderValue("Bearer", Token) : null;
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            if (!string.IsNullOrEmpty(Token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and retrieves the result as an HTTP Response Message
@@ -140,18 +111,12 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         /// <summary>
         /// Triggers a PUT request to the specified route with headers and authorization and retrieves the result as an HTTP Response Message
@@ -163,20 +128,15 @@ namespace HttpClientServiceHelper
         /// <returns>an HTTP Response Message as string</returns>
         public static async Task<string> PutAndGetResponseAsStringAsync(string Route, object Model, List<Header> Headers, Authorization Authorization)
         {
-            using (HttpClient httpClient = new HttpClient())
-            {
-                var uri = new Uri(Route);
-                foreach (var Header in Headers)
-                {
-                    httpClient.DefaultRequestHeaders.Add(Header.Name, Header.Value);
-                }
-                httpClient.DefaultRequestHeaders.Authorization = string.IsNullOrEmpty(Authorization.Parameter) ?
-                    new AuthenticationHeaderValue(Authorization.Scheme) : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
-                string jsonTransport = JsonConvert.SerializeObject(Model);
-                var jsonPayload = new StringContent(jsonTransport, Encoding.UTF8, "application/json");
-                var httpResponse = await httpClient.PutAsync(uri, jsonPayload);
-                return await httpResponse.Content.ReadAsStringAsync();
-            }
+            var request = new HttpRequestMessage(HttpMethod.Put, new Uri(Route));
+            foreach (var Header in Headers)
+                request.Headers.Add(Header.Name, Header.Value);
+            request.Headers.Authorization = string.IsNullOrEmpty(Authorization.Parameter)
+                ? new AuthenticationHeaderValue(Authorization.Scheme)
+                : new AuthenticationHeaderValue(Authorization.Scheme, Authorization.Parameter);
+            request.Content = new StringContent(JsonConvert.SerializeObject(Model), Encoding.UTF8, "application/json");
+            var httpResponse = await _httpClient.SendAsync(request);
+            return await httpResponse.Content.ReadAsStringAsync();
         }
         #region TODO
         /// <summary>


### PR DESCRIPTION
## Summary

Closes #36.

Every public method in the library was creating and disposing a fresh `HttpClient` inside a `using` block:

```csharp
// Before — repeated in every method across all 5 files
using (HttpClient httpClient = new HttpClient())
{
    httpClient.DefaultRequestHeaders.Authorization = ...;
    var httpResponse = await httpClient.GetAsync(new Uri(Route));
    return httpResponse;
}
```

This is the well-documented .NET anti-pattern described in [Microsoft's HttpClient guidelines](https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines). Each construction opens a new socket; `Dispose()` does **not** immediately release it — the OS holds the connection in `TIME_WAIT`. Under any meaningful request volume this exhausts the available socket pool and causes `SocketException`.

### Fix

Introduced a single `private static readonly HttpClient _httpClient` in `Get.cs` (shared across all partial-class files). All active methods now build a per-request `HttpRequestMessage` and pass it to `_httpClient.SendAsync(request)`:

```csharp
// After — shared instance, per-request message
private static readonly HttpClient _httpClient = new HttpClient();

public static async Task<HttpResponseMessage> GetAsync(string Route, string Token = null)
{
    var request = new HttpRequestMessage(HttpMethod.Get, new Uri(Route));
    if (!string.IsNullOrEmpty(Token))
        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", Token);
    return await _httpClient.SendAsync(request);
}
```

Using `HttpRequestMessage` is required here: per-call headers (Authorization, custom) are set on the **message**, not on `DefaultRequestHeaders`, so concurrent calls cannot race on shared state.

### Files changed

| File | Change |
|---|---|
| `Get.cs` | Added `_httpClient` static field; all 8 active methods use `HttpRequestMessage` |
| `Post.cs` | All 8 active methods use `HttpRequestMessage` |
| `Put.cs` | All 8 active methods use `HttpRequestMessage` |
| `Patch.cs` | All 8 active methods use `HttpRequestMessage` |
| `Delete.cs` | All 8 active methods use `HttpRequestMessage` |

### Non-breaking

Public API signatures are unchanged. The `#region TODO` commented-out blocks are preserved (tracked separately in #37).

## Test plan

- [ ] Build passes (`dotnet build`)
- [ ] Existing WireMock integration tests pass (`dotnet test`)
- [ ] Verify no `SocketException` under concurrent load (manual or load test)


---
_Generated by [Claude Code](https://claude.ai/code/session_017UYycZdCbuWRNpNEDXNkXo)_